### PR TITLE
Fix getPos() not including children positioned before itself

### DIFF
--- a/src/tokentree/TokenTree.hx
+++ b/src/tokentree/TokenTree.hx
@@ -74,8 +74,8 @@ class TokenTree extends Token {
 		var childPos:Position;
 		for (child in children) {
 			childPos = child.getPos();
-			if (childPos.min < pos.min) fullPos.min = childPos.min;
-			if (childPos.max > pos.max) fullPos.max = childPos.max;
+			if (childPos.min < fullPos.min) fullPos.min = childPos.min;
+			if (childPos.max > fullPos.max) fullPos.max = childPos.max;
 		}
 		return fullPos;
 	}


### PR DESCRIPTION
e.g. `public` in `public var foo:Int;`