### PR TITLE
Fix TokenTree.getPos() when pos is null

### DIFF
--- a/src/tokentree/TokenTree.hx
+++ b/src/tokentree/TokenTree.hx
@@ -83,7 +83,7 @@ class TokenTree {
 	}
 
 	public function getPos():Position {
-		if ((children == null) || (children.length <= 0)) return pos;
+		if ((children == null) || (children.length <= 0) || (pos == null)) return pos;
 		var fullPos:Position = {file: pos.file, min: pos.min, max: pos.max};
 		var childPos:Position;
 		for (child in children) {


### PR DESCRIPTION
This fixes a `Cannot read properties of null (reading 'file')` error in vshaxe when using go to definition feature